### PR TITLE
Clarify custom Client.commands property usage

### DIFF
--- a/guide/creating-your-bot/command-handling.md
+++ b/guide/creating-your-bot/command-handling.md
@@ -175,6 +175,10 @@ for (const file of commandFiles) {
 }
 ```
 
+::: tip
+The `commands` property doesn't exist on the `Client` class by default, and it's not anything special (you could in fact call it whatever you like). We suggest adding it to the client like this so that you have access to it wherever you use your client.
+:::
+
 Use the same approach for your `deploy-commands.js` file, but instead `.push()` to the `commands` array with the JSON data for each command.
 
 ```js {1,7,9-12}


### PR DESCRIPTION
Primarily to avoid confusion by consumers using typescript. I was motivated to add this after experiencing this issue https://github.com/discordjs/discord.js/issues/6638. I appreciate the guide is meant to be as accessible as possible, and focuses on JS rather than TS. I think this could still be helpful though - anecdotally more and more people are adopting TS. There's at least [a few others](https://stackoverflow.com/questions/62860164/stuck-with-adding-variable-to-discord-client-object-typescript) that have experienced this.

On the other hand, I understand if this feels like extra noise in a guide that's supposed to be focused on getting people up and running, so no worries if it doesn't feel like a good addition.

